### PR TITLE
Prevent WaitingTasks counter to wrap around and upgrade to Go v1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ go:
   - 1.13.x
   - 1.14.x
   - 1.15.x
+  - 1.16.x
 
 # Enable Go Modules
 env:

--- a/examples/dynamic_size/go.mod
+++ b/examples/dynamic_size/go.mod
@@ -1,9 +1,9 @@
 module github.com/alitto/pond/examples/dynamic_size
 
-go 1.15
+go 1.16
 
 require (
-	github.com/alitto/pond v1.5.0
+	github.com/alitto/pond v1.5.1
 )
 
 replace github.com/alitto/pond => ../../

--- a/examples/fixed_size/go.mod
+++ b/examples/fixed_size/go.mod
@@ -1,9 +1,9 @@
 module github.com/alitto/pond/examples/fixed_size
 
-go 1.15
+go 1.16
 
 require (
-	github.com/alitto/pond v1.5.0
+	github.com/alitto/pond v1.5.1
 )
 
 replace github.com/alitto/pond => ../../

--- a/examples/prometheus/go.mod
+++ b/examples/prometheus/go.mod
@@ -1,9 +1,9 @@
 module github.com/alitto/pond/examples/fixed_size
 
-go 1.15
+go 1.16
 
 require (
-	github.com/alitto/pond v1.5.0
+	github.com/alitto/pond v1.5.1
 	github.com/prometheus/client_golang v1.9.0
 )
 

--- a/examples/task_group/go.mod
+++ b/examples/task_group/go.mod
@@ -1,9 +1,9 @@
 module github.com/alitto/pond/examples/task_group
 
-go 1.15
+go 1.16
 
 require (
-	github.com/alitto/pond v1.5.0
+	github.com/alitto/pond v1.5.1
 )
 
 replace github.com/alitto/pond => ../../

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/alitto/pond
 
-go 1.15
+go 1.16


### PR DESCRIPTION
### Changes:
- Prevent `waitingTasks` counter to wrap around (https://github.com/alitto/pond/issues/12)
- Upgrade go to v1.16