### PR TITLE
Allow concurrent calls to StopAndWait

### DIFF
--- a/benchmark/go.mod
+++ b/benchmark/go.mod
@@ -3,7 +3,7 @@ module github.com/alitto/pond/benchmark
 go 1.17
 
 require (
-	github.com/alitto/pond v1.6.1
+	github.com/alitto/pond v1.7.0
 	github.com/gammazero/workerpool v1.1.2
 	github.com/panjf2000/ants/v2 v2.4.7
 )

--- a/examples/dynamic_size/go.mod
+++ b/examples/dynamic_size/go.mod
@@ -3,7 +3,7 @@ module github.com/alitto/pond/examples/dynamic_size
 go 1.17
 
 require (
-	github.com/alitto/pond v1.6.1
+	github.com/alitto/pond v1.7.0
 )
 
 replace github.com/alitto/pond => ../../

--- a/examples/fixed_size/go.mod
+++ b/examples/fixed_size/go.mod
@@ -3,7 +3,7 @@ module github.com/alitto/pond/examples/fixed_size
 go 1.17
 
 require (
-	github.com/alitto/pond v1.6.1
+	github.com/alitto/pond v1.7.0
 )
 
 replace github.com/alitto/pond => ../../

--- a/examples/pool_context/go.mod
+++ b/examples/pool_context/go.mod
@@ -2,6 +2,6 @@ module github.com/alitto/pond/examples/pool_context
 
 go 1.17
 
-require github.com/alitto/pond v1.6.1
+require github.com/alitto/pond v1.7.0
 
 replace github.com/alitto/pond => ../../

--- a/examples/prometheus/go.mod
+++ b/examples/prometheus/go.mod
@@ -3,7 +3,7 @@ module github.com/alitto/pond/examples/fixed_size
 go 1.17
 
 require (
-	github.com/alitto/pond v1.6.1
+	github.com/alitto/pond v1.7.0
 	github.com/prometheus/client_golang v1.9.0
 )
 

--- a/examples/task_group/go.mod
+++ b/examples/task_group/go.mod
@@ -3,7 +3,7 @@ module github.com/alitto/pond/examples/task_group
 go 1.17
 
 require (
-	github.com/alitto/pond v1.6.1
+	github.com/alitto/pond v1.7.0
 )
 
 replace github.com/alitto/pond => ../../

--- a/pond_test.go
+++ b/pond_test.go
@@ -43,6 +43,6 @@ func TestPurgeAfterPoolStopped(t *testing.T) {
 	assertEqual(t, 1, pool.RunningWorkers())
 
 	// Simulate purger goroutine attempting to stop a worker after tasks channel is closed
-	pool.stopped = true
+	atomic.StoreInt32(&pool.stopped, 1)
 	pool.stopIdleWorker()
 }

--- a/resizer.go
+++ b/resizer.go
@@ -2,7 +2,6 @@ package pond
 
 import (
 	"runtime"
-	"sync/atomic"
 )
 
 var maxProcs = runtime.GOMAXPROCS(0)
@@ -25,8 +24,8 @@ var (
 
 // ratedResizer implements a rated resizing strategy
 type ratedResizer struct {
-	rate int
-	hits int32
+	rate uint64
+	hits uint64
 }
 
 // RatedResizer creates a resizing strategy which can be configured
@@ -40,7 +39,7 @@ func RatedResizer(rate int) ResizingStrategy {
 	}
 
 	return &ratedResizer{
-		rate: rate,
+		rate: uint64(rate),
 	}
 }
 
@@ -50,7 +49,7 @@ func (r *ratedResizer) Resize(runningWorkers, minWorkers, maxWorkers int) bool {
 		return true
 	}
 
-	hits := int(atomic.AddInt32(&r.hits, 1))
+	r.hits++
 
-	return hits%r.rate == 1
+	return r.hits%r.rate == 1
 }


### PR DESCRIPTION
## Changes included
- Allow concurrent calls to StopAndWait
- Restore semantics of `Stop` method, which shouldn't wait for queued tasks to complete before killing worker goroutines
- Simplify logic in submit function
- Prevent `hits` counter in RatedResizer from going to negative values
- Add more tests