### PR TITLE
Prevent deadlock when purging idle worker during task submission

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Test
-      run: go test -race -v ./
+      run: make test
   codecov:
     name: Upload coverage report to Codecov
     runs-on: ubuntu-latest
@@ -33,9 +33,9 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Test
-      run: go test -race -v -coverprofile=coverage.txt -covermode=atomic ./
+      run: make coverage
     - uses: codecov/codecov-action@v2
       with:
-        files: ./coverage.txt
+        files: coverage.out
         fail_ci_if_error: true
         verbose: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x, 1.18.x]
+        go-version: [1.15.x, 1.16.x, 1.17.x, 1.18.x, 1.19.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+test:
+	go test -race -v ./
+
+coverage:
+	go test -race -v -coverprofile=coverage.out -covermode=atomic ./

--- a/examples/dynamic_size/go.mod
+++ b/examples/dynamic_size/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/dynamic_size
 
-go 1.18
+go 1.19
 
 require (
 	github.com/alitto/pond v1.7.1

--- a/examples/fixed_size/go.mod
+++ b/examples/fixed_size/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/fixed_size
 
-go 1.18
+go 1.19
 
 require (
 	github.com/alitto/pond v1.7.1

--- a/examples/group_context/go.mod
+++ b/examples/group_context/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/group_context
 
-go 1.18
+go 1.19
 
 require (
 	github.com/alitto/pond v1.7.1

--- a/examples/pool_context/go.mod
+++ b/examples/pool_context/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/pool_context
 
-go 1.18
+go 1.19
 
 require github.com/alitto/pond v1.7.1
 

--- a/examples/prometheus/go.mod
+++ b/examples/prometheus/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/fixed_size
 
-go 1.18
+go 1.19
 
 require (
 	github.com/alitto/pond v1.7.1

--- a/examples/task_group/go.mod
+++ b/examples/task_group/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/task_group
 
-go 1.18
+go 1.19
 
 require (
 	github.com/alitto/pond v1.7.1

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/alitto/pond
 
-go 1.18
+go 1.19

--- a/worker.go
+++ b/worker.go
@@ -1,0 +1,35 @@
+package pond
+
+import (
+	"context"
+	"sync"
+)
+
+// worker represents a worker goroutine
+func worker(context context.Context, waitGroup *sync.WaitGroup, firstTask func(), tasks <-chan func(), taskExecutor func(func(), bool)) {
+
+	// If provided, execute the first task immediately, before listening to the tasks channel
+	if firstTask != nil {
+		taskExecutor(firstTask, true)
+	}
+
+	defer func() {
+		waitGroup.Done()
+	}()
+
+	for {
+		select {
+		case <-context.Done():
+			// Pool context was cancelled, exit
+			return
+		case task, ok := <-tasks:
+			if task == nil || !ok {
+				// We have received a signal to exit
+				return
+			}
+
+			// We have received a task, execute it
+			taskExecutor(task, false)
+		}
+	}
+}


### PR DESCRIPTION
- Fix for https://github.com/alitto/pond/issues/33
- Upgrade to go 1.19
- Extracted counter updates from main `worker` function to make it simpler and more generic
- Moved `worker` function to a separate file
- Added `Makefile` with test targets