### PR TITLE
Return Context error if it is canceled before at least 1 task failed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Test
       run: make coverage
-    - uses: codecov/codecov-action@v2
+    - uses: codecov/codecov-action@v3
       with:
         files: coverage.out
         fail_ci_if_error: true


### PR DESCRIPTION
- As pointed out by @NOMORECOFFEE in https://github.com/alitto/pond/pull/37#pullrequestreview-1163451413, make sure Context's error is returned by `Wait()` when it's completed (canceled/timed out) before at least 1 task returned an non-nil error.
- Upgrade codecov-action to v3 https://github.com/codecov/codecov-action