### PR TITLE
Added option to WorkGroup to limit the number of concurrently runned tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,20 @@ Configures a parent context on this pool to stop all workers when it is cancelle
 pool := pond.New(10, 1000, pond.Context(myCtx))
 ``` 
 
+### WorkGroup configuration options
+
+#### MaxTasks
+
+Limits the number of tasks that can be executed concurrently in the group. Example:
+
+``` go
+pool := pond.New(10, 100)
+
+// This a group that will execute at most 30 tasks at time. Any exceding submision to the group will be blocked
+group := pool.Group(pond.GroupMaxTasks(30))
+``` 
+
+
 ### Resizing strategies
 
 The following chart illustrates the behaviour of the different pool resizing strategies as the number of submitted tasks increases. Each line represents the number of worker goroutines in the pool (pool size) and the x-axis reflects the number of submitted tasks (cumulative). 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/alitto/pond
 
 go 1.19
+
+require golang.org/x/sync v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=

--- a/group_blackbox_test.go
+++ b/group_blackbox_test.go
@@ -38,6 +38,28 @@ func TestGroupSubmit(t *testing.T) {
 	assertEqual(t, int32(taskCount), atomic.LoadInt32(&doneCount))
 }
 
+func TestGroupSubmitWithTasksLimit(t *testing.T) {
+
+	pool := pond.New(5, 50)
+	assertEqual(t, 0, pool.RunningWorkers())
+
+	group := pool.Group(pond.GroupMaxTasks(5))
+
+	// Submit groups of tasks
+	var doneCount, taskCount int32
+	for i := 0; i < 100; i++ {
+		group.Submit(func() {
+			time.Sleep(1 * time.Millisecond)
+			atomic.AddInt32(&doneCount, 1)
+		})
+		taskCount++
+	}
+
+	group.Wait()
+
+	assertEqual(t, int32(taskCount), atomic.LoadInt32(&doneCount))
+}
+
 func TestGroupContext(t *testing.T) {
 
 	pool := pond.New(3, 100)

--- a/pond.go
+++ b/pond.go
@@ -522,28 +522,40 @@ func (p *WorkerPool) resetWorkerCount() {
 }
 
 // Group creates a new task group
-func (p *WorkerPool) Group() *TaskGroup {
-	return &TaskGroup{
+func (p *WorkerPool) Group(options ...GroupOption) *TaskGroup {
+	group := &TaskGroup{
 		pool: p,
 	}
+
+	for _, opt := range options {
+		opt(group)
+	}
+
+	return group
 }
 
 // GroupContext creates a new task group and an associated Context derived from ctx.
 //
 // The derived Context is canceled the first time a function submitted to the group
 // returns a non-nil error or the first time Wait returns, whichever occurs first.
-func (p *WorkerPool) GroupContext(ctx context.Context) (*TaskGroupWithContext, context.Context) {
+func (p *WorkerPool) GroupContext(ctx context.Context, options ...GroupOption) (*TaskGroupWithContext, context.Context) {
 
 	if ctx == nil {
 		panic("a non-nil context needs to be specified when using GroupContext")
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
-	return &TaskGroupWithContext{
+	group := &TaskGroupWithContext{
 		TaskGroup: TaskGroup{
 			pool: p,
 		},
 		ctx:    ctx,
 		cancel: cancel,
-	}, ctx
+	}
+
+	for _, opt := range options {
+		opt(&group.TaskGroup)
+	}
+
+	return group, ctx
 }


### PR DESCRIPTION
As a possible resolution of the problem presented in #59 I added option limit number of tasks in group.

Unfortunatelly, i had to add `golang.org/x/sync v0.7.0` library, so now there is dependency.