### PR TITLE
chore(workflows): update go version and tested versions in github actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x, 1.17.x, 1.18.x, 1.19.x]
+        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/examples/dynamic_size/go.mod
+++ b/examples/dynamic_size/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/dynamic_size
 
-go 1.19
+go 1.21
 
 require (
 	github.com/alitto/pond v1.7.1

--- a/examples/fixed_size/go.mod
+++ b/examples/fixed_size/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/fixed_size
 
-go 1.19
+go 1.21
 
 require (
 	github.com/alitto/pond v1.7.1

--- a/examples/group_context/go.mod
+++ b/examples/group_context/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/group_context
 
-go 1.19
+go 1.21
 
 require (
 	github.com/alitto/pond v1.7.1

--- a/examples/pool_context/go.mod
+++ b/examples/pool_context/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/pool_context
 
-go 1.19
+go 1.21
 
 require github.com/alitto/pond v1.7.1
 

--- a/examples/prometheus/go.mod
+++ b/examples/prometheus/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/fixed_size
 
-go 1.19
+go 1.21
 
 require (
 	github.com/alitto/pond v1.7.1

--- a/examples/task_group/go.mod
+++ b/examples/task_group/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/task_group
 
-go 1.19
+go 1.21
 
 require (
 	github.com/alitto/pond v1.7.1

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/alitto/pond
 
-go 1.19
+go 1.21


### PR DESCRIPTION
## Changes included

- Updated list of go versions used in github actions workflow
- Bumped module's go version to `1.21` (when selecting `1.22` github actions crash with an error) 