### PR TITLE
chore(go): bump max supported go version to 1.22

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,36 +4,41 @@ on:
       - master
       - main
   pull_request:
-name: Build
+name: Test
 jobs:
   test:
-    name: Test
+    name: Run tests
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x]
+        go-version: [1.22.x, 1.21.x, 1.20.x, 1.19.x, 1.18.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Checkout code
-      uses: actions/checkout@v2
+
     - name: Test
       run: make test
   codecov:
-    name: Upload coverage report to Codecov
+    name: Coverage report
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
     - name: Test
       run: make coverage
+
     - uses: codecov/codecov-action@v4
       with:
         files: coverage.out

--- a/examples/dynamic_size/go.mod
+++ b/examples/dynamic_size/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/dynamic_size
 
-go 1.21
+go 1.18
 
 require (
 	github.com/alitto/pond v1.7.1

--- a/examples/fixed_size/go.mod
+++ b/examples/fixed_size/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/fixed_size
 
-go 1.21
+go 1.18
 
 require (
 	github.com/alitto/pond v1.7.1

--- a/examples/group_context/go.mod
+++ b/examples/group_context/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/group_context
 
-go 1.21
+go 1.18
 
 require (
 	github.com/alitto/pond v1.7.1

--- a/examples/pool_context/go.mod
+++ b/examples/pool_context/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/pool_context
 
-go 1.21
+go 1.18
 
 require github.com/alitto/pond v1.7.1
 

--- a/examples/prometheus/go.mod
+++ b/examples/prometheus/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/fixed_size
 
-go 1.21
+go 1.18
 
 require (
 	github.com/alitto/pond v1.7.1

--- a/examples/task_group/go.mod
+++ b/examples/task_group/go.mod
@@ -1,6 +1,6 @@
 module github.com/alitto/pond/examples/task_group
 
-go 1.21
+go 1.18
 
 require (
 	github.com/alitto/pond v1.7.1

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/alitto/pond
 
-go 1.21
+go 1.18


### PR DESCRIPTION
- Bump max supported go version to 1.22
- Correct go version specified in `go.mod` to reflect the minimum version of the Go compiler that is supported by the source code
- Upgrade versions of actions in Github Actions workflows