### PR TITLE
Fix bug that worker doesn't return after context cancel

### DIFF
--- a/worker.go
+++ b/worker.go
@@ -31,6 +31,7 @@ func worker(context context.Context, waitGroup *sync.WaitGroup, firstTask func()
 					// We have received a task, ignore it
 					taskWaitGroup.Done()
 				}
+				return
 			default:
 				if task == nil || !ok {
 					// We have received a signal to exit

--- a/worker.go
+++ b/worker.go
@@ -31,6 +31,8 @@ func worker(context context.Context, waitGroup *sync.WaitGroup, firstTask func()
 					// We have received a task, ignore it
 					taskWaitGroup.Done()
 				}
+				// Pool context was cancelled, empty tasks channel and exit
+				drainTasks(tasks, taskWaitGroup)
 				return
 			default:
 				if task == nil || !ok {


### PR DESCRIPTION
I think we also need to return immediately in the inner `context.Done()`, otherwise it is possible to loop all the time. According to https://stackoverflow.com/a/51296312, it also returns immediately.