### PR TITLE
fix(taskgroups): do not start remaining tasks after context cancellation

### DIFF
--- a/internal/future/composite.go
+++ b/internal/future/composite.go
@@ -39,6 +39,10 @@ func NewCompositeFuture[V any](ctx context.Context) (*CompositeFuture[V], Compos
 	return future, future.resolve
 }
 
+func (f *CompositeFuture[V]) Context() context.Context {
+	return f.ctx
+}
+
 func (f *CompositeFuture[V]) Wait(count int) ([]V, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()


### PR DESCRIPTION
- Skip remaining tasks in a task group after its context is cancelled
- Improve documentation around usage of `context.Context`