### PR TITLE
feat(taskgroup): wait for ongoing tasks complete when group is stopped or context is cancelled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	go test -race -v -timeout 1m ./
+	go test -race -v -timeout 1m ./...
 
 coverage:
-	go test -race -v -timeout 1m -coverprofile=coverage.out -covermode=atomic ./
+	go test -race -v -timeout 1m -coverprofile=coverage.out -covermode=atomic ./...

--- a/internal/dispatcher/dispatcher_test.go
+++ b/internal/dispatcher/dispatcher_test.go
@@ -96,7 +96,7 @@ func TestDispatcherWithContextCanceledAfterWrite(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 
-	receivedCount := atomic.Uint64{}
+	var receivedCount atomic.Uint64
 	receiveFunc := func(elems []int) {
 		for range elems {
 			receivedCount.Add(1)
@@ -110,16 +110,18 @@ func TestDispatcherWithContextCanceledAfterWrite(t *testing.T) {
 	assert.Equal(t, uint64(0), dispatcher.WriteCount())
 	assert.Equal(t, uint64(0), dispatcher.ReadCount())
 
+	dispatcher.Write(1)
+	time.Sleep(5 * time.Millisecond)
+
 	// Cancel the context
-	dispatcher.Write(1)
-	time.Sleep(5 * time.Millisecond) // Wait for the dispatcher to process the element
 	cancel()
+
 	dispatcher.Write(1)
-	time.Sleep(5 * time.Millisecond) // Wait for the dispatcher to process the element
+	time.Sleep(5 * time.Millisecond)
 
 	// Assert counters
-	assert.Equal(t, uint64(1), dispatcher.Len())
-	assert.Equal(t, uint64(2), dispatcher.WriteCount())
+	assert.Equal(t, uint64(0), dispatcher.Len())
+	assert.Equal(t, uint64(1), dispatcher.WriteCount())
 	assert.Equal(t, uint64(1), dispatcher.ReadCount())
 }
 

--- a/internal/future/composite_test.go
+++ b/internal/future/composite_test.go
@@ -36,7 +36,10 @@ func TestCompositeFutureWaitWithError(t *testing.T) {
 	outputs, err := future.Wait(3)
 
 	assert.Equal(t, sampleErr, err)
-	assert.Equal(t, 0, len(outputs))
+	assert.Equal(t, 3, len(outputs))
+	assert.Equal(t, "output1", outputs[0])
+	assert.Equal(t, "output2", outputs[1])
+	assert.Equal(t, "", outputs[2])
 }
 
 func TestCompositeFutureWaitWithCanceledContext(t *testing.T) {
@@ -47,7 +50,7 @@ func TestCompositeFutureWaitWithCanceledContext(t *testing.T) {
 
 	resolve(0, "output1", nil)
 
-	_, err := future.Wait(2)
+	_, err := future.Wait(1)
 
 	assert.Equal(t, context.Canceled, err)
 }
@@ -92,7 +95,8 @@ func TestCompositeFutureWithErrorsAndMultipleWait(t *testing.T) {
 	outputs1, err := future.Wait(1)
 
 	assert.Equal(t, sampleErr, err)
-	assert.Equal(t, 0, len(outputs1))
+	assert.Equal(t, 1, len(outputs1))
+	assert.Equal(t, "", outputs1[0])
 
 	resolve(1, "output2", nil)
 	resolve(2, "output3", nil)
@@ -100,7 +104,10 @@ func TestCompositeFutureWithErrorsAndMultipleWait(t *testing.T) {
 	outputs, err := future.Wait(3)
 
 	assert.Equal(t, sampleErr, err)
-	assert.Equal(t, 0, len(outputs))
+	assert.Equal(t, 3, len(outputs))
+	assert.Equal(t, "", outputs[0])
+	assert.Equal(t, "", outputs[1])
+	assert.Equal(t, "", outputs[2])
 }
 
 func TestCompositeFutureWaitBeforeResoluion(t *testing.T) {
@@ -130,7 +137,8 @@ func TestCompositeFutureWaitBeforeContextCanceled(t *testing.T) {
 	outputs, err := future.Wait(1)
 
 	assert.Equal(t, context.Canceled, err)
-	assert.Equal(t, 0, len(outputs))
+	assert.Equal(t, 1, len(outputs))
+	assert.Equal(t, "", outputs[0])
 }
 
 func TestCompositeFutureWaitWithContextCanceledAfterResolution(t *testing.T) {
@@ -182,7 +190,8 @@ func TestCompositeFutureWithErrorsAndMultipleDone(t *testing.T) {
 	<-future.Done(1)
 
 	assert.Equal(t, sampleErr, err)
-	assert.Equal(t, 0, len(outputs1))
+	assert.Equal(t, 1, len(outputs1))
+	assert.Equal(t, "", outputs1[0])
 
 	resolve(1, "output2", nil)
 	resolve(2, "output3", nil)
@@ -191,7 +200,7 @@ func TestCompositeFutureWithErrorsAndMultipleDone(t *testing.T) {
 	<-future.Done(3)
 
 	assert.Equal(t, sampleErr, err)
-	assert.Equal(t, 0, len(outputs))
+	assert.Equal(t, 3, len(outputs))
 }
 
 func TestCompositeFutureCancel(t *testing.T) {

--- a/result.go
+++ b/result.go
@@ -1,6 +1,8 @@
 package pond
 
 import (
+	"context"
+
 	"github.com/alitto/pond/v2/internal/future"
 )
 
@@ -19,6 +21,9 @@ type ResultPool[R any] interface {
 
 	// Creates a new task group.
 	NewGroup() ResultTaskGroup[R]
+
+	// Creates a new task group with the specified context.
+	NewGroupContext(ctx context.Context) ResultTaskGroup[R]
 }
 
 type resultPool[R any] struct {
@@ -27,6 +32,10 @@ type resultPool[R any] struct {
 
 func (p *resultPool[R]) NewGroup() ResultTaskGroup[R] {
 	return newResultTaskGroup[R](p.pool, p.Context())
+}
+
+func (p *resultPool[R]) NewGroupContext(ctx context.Context) ResultTaskGroup[R] {
+	return newResultTaskGroup[R](p.pool, ctx)
 }
 
 func (p *resultPool[R]) Submit(task func() R) Result[R] {


### PR DESCRIPTION
This pull request includes multiple changes to improve the task group functionalities and their associated tests in the `pond` package. The most important changes include updating the `Wait` method behavior, adding context support to task groups, and enhancing test cases to cover new scenarios.

### Enhancements to Task Group Functionality:

* Allow running tasks to complete if a group is stopped or its context is cancelled.
* Return result values of tasks that have completed instead of an empty slice when a group is stopped, its context is cancelled or one of the tasks returns an error.
* Added detailed comments to the `Wait` methods in `TaskGroup` and `ResultTaskGroup` interfaces to clarify the behavior when tasks return errors, the context is canceled, or the group is stopped.
* Added `NewGroupContext` method to `ResultPool` to create task groups with a specified context.
* Improved the `CompositeFuture` to handle context cancellation and error resolution more effectively.

### Test Case Improvements:

* Updated test cases to validate the new `Wait` method behavior, including scenarios with errors, context cancellation, and multiple errors.
* Enhanced `CompositeFuture` test cases to ensure proper handling of errors and context cancellation.

### Minor Fixes:

* Updated `Makefile` to run tests recursively.
* Fixed variable initialization in `TestDispatcherWithContextCanceledAfterWrite` test.