### PR TITLE
fix(taskgroup): failed group tasks not counted

### DIFF
--- a/group.go
+++ b/group.go
@@ -104,7 +104,7 @@ func (g *abstractTaskGroup[T, E, O]) submit(task any) {
 
 	g.taskWaitGroup.Add(1)
 
-	err := g.pool.Go(func() {
+	err := g.pool.dispatcher.Write(func() error {
 		defer g.taskWaitGroup.Done()
 
 		// Check if the context has been cancelled to prevent running tasks that are not needed
@@ -112,7 +112,7 @@ func (g *abstractTaskGroup[T, E, O]) submit(task any) {
 			g.futureResolver(index, &result[O]{
 				Err: err,
 			}, err)
-			return
+			return err
 		}
 
 		// Invoke the task
@@ -122,6 +122,8 @@ func (g *abstractTaskGroup[T, E, O]) submit(task any) {
 			Output: output,
 			Err:    err,
 		}, err)
+
+		return err
 	})
 
 	if err != nil {


### PR DESCRIPTION
This pull request includes changes to the `group.go` file to improve task submission handling and adds new test cases to ensure the functionality of task group metrics and handling of cancelled contexts.

### Improvements to task submission:

* Changed the `submit` function to use `g.pool.dispatcher.Write` for task execution, which returns an error if the context is cancelled or an error occurs during task invocation. (`group.go`, [group.goL107-R115](diffhunk://#diff-996f64128c7fffe6cc8254ea4e1ac3c5693956f86ab5c8952e525083cf14ca27L107-R115))
* Added a return statement to ensure the error is properly returned after task completion. (`group.go`, [group.goR125-R126](diffhunk://#diff-996f64128c7fffe6cc8254ea4e1ac3c5693956f86ab5c8952e525083cf14ca27R125-R126))

### New test cases:

* Added `TestTaskGroupMetrics` to verify the correct reporting of submitted, successful, and failed tasks. (`group_test.go`, [group_test.goR326-R371](diffhunk://#diff-176c4119baca13b177944712c9a1f0813fe8a0d03e408d7b1725f38d1bcf5a6aR326-R371))
* Added `TestTaskGroupMetricsWithCancelledContext` to test the behavior of task groups when the context is cancelled, ensuring accurate metrics for successful and failed tasks. (`group_test.go`, [group_test.goR326-R371](diffhunk://#diff-176c4119baca13b177944712c9a1f0813fe8a0d03e408d7b1725f38d1bcf5a6aR326-R371))