### PR TITLE
fix(dispatcher): ensure workers exit reliably when worker count is low

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.22.x, 1.21.x, 1.20.x]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/main.yml` and `pool.go` files to enhance compatibility and improve the worker management logic. The most important changes include adding Windows OS to the CI workflow and refactoring the worker management logic to simplify the code and avoid potential deadlocks.

### CI Workflow Enhancements:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L14-R14): Added `windows-latest` to the list of operating systems in the matrix strategy to ensure compatibility across more environments.

### Worker Management Refactoring:

* [`pool.go`](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2L15-R17): Introduced `NUM_CPU` variable to store the number of CPUs and used it to define `MAX_TASKS_CHAN_LENGTH`.
* [`pool.go`](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2L244-R261): Simplified the `startWorker` function by removing the `canExitDuringDispatch` parameter and updating the `worker` function call accordingly.
* [`pool.go`](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2L272-R273): Refactored the `workerCanExit` function to remove the `canExitDuringDispatch` parameter and added a check to allow worker exit if the number of workers exceeds the number of CPUs.
* [`pool.go`](diffhunk://#diff-5c0127b47636d901a18590597909d34f79c1e67840557675b5a981c26f7601e2L309-R310): Updated the `worker` function to call the refactored `workerCanExit` function without the `canExitDuringDispatch` parameter.