### PR TITLE
Fixed write to closed channel in dispatcher

### DIFF
--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -54,3 +54,15 @@ func PanicsWithError(t *testing.T, expected string, f func()) {
 	}()
 	f()
 }
+
+/**
+ * Asserts that the function not panics.
+ */
+func NotPanics(t *testing.T, f func()) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("No panic was expected, but got %T(%v)", r, r)
+		}
+	}()
+	f()
+}


### PR DESCRIPTION
Dispatcher may panic with `send on closed channel`  when pool is closing while new jobs are being added.

`Write` tries to send on `bufferHasElements`, which may be being closed in `Close()` at the same moment. To avoid that, I decided to never close `bufferHasElements` which may seem dirty, but should work fine since `bufferHasElements` will be removed by GC anyway.

I added test case to reproduce the issue as well.