### PR TITLE
fix: Adding stack trace to panic catch errors

### DIFF
--- a/task.go
+++ b/task.go
@@ -3,6 +3,7 @@ package pond
 import (
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"sync"
 )
 
@@ -62,7 +63,7 @@ func wrapTask[R any, C func(error) | func(R, error)](task any, callback C) func(
 func invokeTask[R any](task any) (output R, err error) {
 	defer func() {
 		if p := recover(); p != nil {
-			err = fmt.Errorf("%w: %v", ErrPanic, p)
+			err = fmt.Errorf("%w: %+v, %s", ErrPanic, p, string(debug.Stack()))
 			return
 		}
 	}()


### PR DESCRIPTION
Pond automatically catches panics without any option to surface them, but the wrapped error doesn't contain stack information so it's nearly impossible to track down the issue as is.  This adds a stack trace to the wrapped error generated out of the recover function.