### PR TITLE
fix(panics): wrap panic errors correctly and include stack trace

### DIFF
--- a/default_test.go
+++ b/default_test.go
@@ -2,6 +2,7 @@ package pond
 
 import (
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -41,7 +42,7 @@ func TestSubmitWithPanic(t *testing.T) {
 	err := task.Wait()
 
 	assert.True(t, errors.Is(err, ErrPanic))
-	assert.Equal(t, "task panicked: dummy panic", err.Error())
+	assert.True(t, strings.HasPrefix(err.Error(), "task panicked: dummy panic"))
 }
 
 func TestNewGroup(t *testing.T) {

--- a/result_test.go
+++ b/result_test.go
@@ -2,6 +2,7 @@ package pond
 
 import (
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -34,7 +35,7 @@ func TestResultPoolSubmitTaskWithPanic(t *testing.T) {
 	output, err := task.Wait()
 
 	assert.True(t, errors.Is(err, ErrPanic))
-	assert.Equal(t, "task panicked: dummy panic", err.Error())
+	assert.True(t, strings.HasPrefix(err.Error(), "task panicked: dummy panic"))
 	assert.Equal(t, 0, output)
 }
 

--- a/task.go
+++ b/task.go
@@ -3,6 +3,7 @@ package pond
 import (
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"sync"
 )
 
@@ -62,7 +63,11 @@ func wrapTask[R any, C func(error) | func(R, error)](task any, callback C) func(
 func invokeTask[R any](task any) (output R, err error) {
 	defer func() {
 		if p := recover(); p != nil {
-			err = fmt.Errorf("%w: %v", ErrPanic, p)
+			if e, ok := p.(error); ok {
+				err = fmt.Errorf("%w: %w, %s", ErrPanic, e, debug.Stack())
+			} else {
+				err = fmt.Errorf("%w: %v, %s", ErrPanic, p, debug.Stack())
+			}
 			return
 		}
 	}()


### PR DESCRIPTION
- Ensure panics thrown by tasks are wrapped correctly with `ErrPanic`.
- Include stack trace in wrapped error (inspired by https://github.com/alitto/pond/pull/94)