### PR TITLE
feat(pool): add support for dynamically adjusting max concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Some common use cases include:
   - Panics recovery (panics are captured and returned as errors)
   - Subpools with a fraction of the parent pool's maximum number of workers
   - Blocking and non-blocking submission of tasks when the queue is full
+  - Dynamic resizing of the pool
 - [API reference](https://pkg.go.dev/github.com/alitto/pond/v2)
 
 ## Installation
@@ -405,6 +406,40 @@ When a pool defines a queue size (bounded), you can also specify how to handle t
 // Create a pool with a maximum of 10 tasks in the queue and non-blocking task submission
 pool := pond.NewPool(1, pond.WithQueueSize(10), pond.WithNonBlocking(true))
 ```
+
+### Resizing pools (v2)
+
+You can dynamically change the maximum number of workers in a pool using the `Resize` method. This is useful when you need to adjust the pool's capacity based on runtime conditions.
+
+``` go
+// Create a pool with 5 workers
+pool := pond.NewPool(5)
+
+// Submit some tasks
+for i := 0; i < 20; i++ {
+    pool.Submit(func() {
+        // Do some work
+    })
+}
+
+// Increase the pool size to 10 workers
+pool.Resize(10)
+
+// Submit more tasks that will use the increased capacity
+for i := 0; i < 20; i++ {
+    pool.Submit(func() {
+        // Do some work
+    })
+}
+
+// Decrease the pool size back to 5 workers
+pool.Resize(5)
+```
+
+When resizing a pool:
+- The new maximum concurrency must be greater than 0
+- If you increase the size, new workers will be created as needed up to the new maximum
+- If you decrease the size, existing workers will continue running until they complete their current tasks, but no new workers will be created until the number of running workers is below the new maximum
 
 ### Metrics & monitoring
 

--- a/subpool_test.go
+++ b/subpool_test.go
@@ -334,3 +334,76 @@ func TestSubpoolWithQueueSizeOverride(t *testing.T) {
 	subpool.StopAndWait()
 	pool.StopAndWait()
 }
+
+func TestSubpoolResize(t *testing.T) {
+
+	parentPool := NewPool(10, WithQueueSize(10))
+
+	pool := parentPool.NewSubpool(1)
+
+	assert.Equal(t, 1, pool.MaxConcurrency())
+	assert.Equal(t, 10, parentPool.MaxConcurrency())
+
+	taskStarted := make(chan struct{}, 10)
+	taskWait := make(chan struct{}, 10)
+
+	// Submit 10 tasks
+	for i := 0; i < 10; i++ {
+		pool.Submit(func() {
+			<-taskStarted
+			<-taskWait
+		})
+	}
+
+	// Unblock 3 tasks
+	for i := 0; i < 3; i++ {
+		taskStarted <- struct{}{}
+	}
+
+	// Verify only 1 task is running and 9 are waiting
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, uint64(9), pool.WaitingTasks())
+	assert.Equal(t, int64(1), pool.RunningWorkers())
+	assert.Equal(t, int64(1), parentPool.RunningWorkers())
+
+	// Increase max concurrency to 3
+	pool.Resize(3)
+	assert.Equal(t, 3, pool.MaxConcurrency())
+	assert.Equal(t, 10, parentPool.MaxConcurrency())
+
+	// Unblock 3 more tasks
+	for i := 0; i < 3; i++ {
+		taskStarted <- struct{}{}
+	}
+
+	// Verify 3 tasks are running and 7 are waiting
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, uint64(7), pool.WaitingTasks())
+	assert.Equal(t, int64(3), pool.RunningWorkers())
+	assert.Equal(t, int64(3), parentPool.RunningWorkers())
+
+	// Decrease max concurrency to 1
+	pool.Resize(2)
+	assert.Equal(t, 2, pool.MaxConcurrency())
+	assert.Equal(t, 10, parentPool.MaxConcurrency())
+
+	// Complete the 3 running tasks
+	for i := 0; i < 3; i++ {
+		taskWait <- struct{}{}
+	}
+
+	// Unblock all remaining tasks
+	for i := 0; i < 4; i++ {
+		taskStarted <- struct{}{}
+	}
+
+	// Ensure 2 tasks are running and 5 are waiting
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, uint64(5), pool.WaitingTasks())
+	assert.Equal(t, int64(2), pool.RunningWorkers())
+	assert.Equal(t, int64(2), parentPool.RunningWorkers())
+
+	close(taskWait)
+
+	pool.Stop().Wait()
+}


### PR DESCRIPTION
Add support for dynamically adjusting the maximum concurrency of the pool (number of workers) via a new method `Resize(maxWorkers int)`