### PR TITLE
Fixed data race in parallel Submit and Stop calls

### DIFF
--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -23,6 +23,16 @@ func True(t *testing.T, actual bool) {
 }
 
 /**
+ * Asserts that the actual value is false.
+ */
+func False(t *testing.T, actual bool) {
+	if actual {
+		t.Helper()
+		t.Errorf("Expected false but was %T(%v)", actual, actual)
+	}
+}
+
+/**
  * Asserts that the function panics with the expected object.
  */
 func PanicsWith(t *testing.T, expected any, f func()) {

--- a/internal/stopper/stopper.go
+++ b/internal/stopper/stopper.go
@@ -1,0 +1,109 @@
+package stopper
+
+import (
+	"sync"
+)
+
+func New() *Stopper {
+	return &Stopper{
+		mu: sync.Mutex{},
+
+		stopping: make(chan struct{}),
+		stopped:  make(chan struct{}),
+	}
+}
+
+// Stopper is a WaitGroup-like thread-safe synchronization primitive
+// which avoids data races when calling Add during active Wait
+type Stopper struct {
+	mu  sync.Mutex
+	cnt int32
+
+	stoppingOnce sync.Once
+	stoppedOnce  sync.Once
+
+	stopping chan struct{}
+	stopped  chan struct{}
+}
+
+// Add increments internal counter of running jobs
+func (s *Stopper) Add(delta int32) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	select {
+	case <-s.stopping:
+		return
+
+	default:
+	}
+
+	s.cnt += delta
+}
+
+// Done decrements internal counter of running jobs
+func (s *Stopper) Done() {
+	s.mu.Lock()
+
+	if s.cnt <= 0 {
+		s.mu.Unlock()
+
+		return
+	}
+
+	s.cnt--
+
+	s.mu.Unlock()
+
+	s.checkIfStopped()
+}
+
+func (s *Stopper) checkIfStopped() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.cnt <= 0 {
+		select {
+		case <-s.stopping:
+			s.stoppedOnce.Do(func() { close(s.stopped) })
+
+		default:
+		}
+	}
+}
+
+// Stop asks all added jobs to stop
+func (s *Stopper) Stop() {
+	s.stoppingOnce.Do(func() {
+		s.mu.Lock()
+		close(s.stopping)
+		s.mu.Unlock()
+
+		s.checkIfStopped()
+	})
+}
+
+// Stopping indicates that jobs are stopping or stopped
+func (s *Stopper) Stopping() bool {
+	select {
+	case <-s.stopping:
+		return true
+	default:
+		return false
+	}
+}
+
+// Stopped indicates that all jobs are stopped
+func (s *Stopper) Stopped() bool {
+	select {
+	case <-s.stopped:
+		return true
+	default:
+		return false
+	}
+}
+
+// Wait for all jobs to stop
+func (s *Stopper) Wait() {
+	<-s.stopped
+}

--- a/internal/stopper/stopper_test.go
+++ b/internal/stopper/stopper_test.go
@@ -1,0 +1,39 @@
+package stopper
+
+import (
+	"github.com/alitto/pond/v2/internal/assert"
+	"testing"
+)
+
+func TestEmptyStopper(t *testing.T) {
+	s := New()
+
+	assert.False(t, s.Stopping())
+	assert.False(t, s.Stopped())
+
+	s.Stop()
+
+	s.Add(1)
+
+	assert.True(t, s.Stopping())
+	assert.True(t, s.Stopped())
+}
+
+func TestStopper(t *testing.T) {
+	s := New()
+
+	assert.False(t, s.Stopping())
+	assert.False(t, s.Stopped())
+
+	s.Add(1)
+
+	s.Stop()
+
+	assert.True(t, s.Stopping())
+	assert.False(t, s.Stopped())
+
+	s.Done()
+
+	assert.True(t, s.Stopping())
+	assert.True(t, s.Stopped())
+}


### PR DESCRIPTION
Hey @alitto !

I discovered that calling `Submit` after `Close` could lead to data race in `WaitGroup` since you cannot call `WaitGroup.Add` while `WaitGroup.Wait` is running.

To fix this I replaced `WaitGroup` with custom synchronization primitive called `Stopper` (yep, naming isn't my suit) which replicates `WaitGroup` behavior but properly handles `Add` — `Wait` race.

Can't say that I'm happy enough with my solution, so I'd be glad to hear your thoughts!