### PR TITLE
fix(pool): avoid race conditions when a task is submitted while the pool is stopping

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ pool.Resize(5)
 ```
 
 When resizing a pool:
-- The new maximum concurrency must be greater than 0
+- The new maximum concurrency must be greater than or equal to 0 (0 means no limit)
 - If you increase the size, new workers will be created as needed up to the new maximum
 - If you decrease the size, existing workers will continue running until they complete their current tasks, but no new workers will be created until the number of running workers is below the new maximum
 

--- a/pool_test.go
+++ b/pool_test.go
@@ -3,6 +3,7 @@ package pond
 import (
 	"context"
 	"errors"
+	"math"
 	"regexp"
 	"sync"
 	"sync/atomic"
@@ -175,7 +176,7 @@ func TestPoolSubmitOnStoppedPool(t *testing.T) {
 }
 
 func TestNewPoolWithInvalidMaxConcurrency(t *testing.T) {
-	assert.PanicsWithError(t, "maxConcurrency must be greater than 0", func() {
+	assert.PanicsWithError(t, "maxConcurrency must be greater than or equal to 0", func() {
 		NewPool(-1)
 	})
 }
@@ -340,6 +341,20 @@ func TestPoolResize(t *testing.T) {
 	close(taskWait)
 
 	pool.Stop().Wait()
+}
+
+func TestPoolResizeWithZeroMaxConcurrency(t *testing.T) {
+	pool := NewPool(10)
+
+	pool.Resize(0)
+
+	assert.Equal(t, math.MaxInt, pool.MaxConcurrency())
+}
+
+func TestPoolResizeWithNegativeMaxConcurrency(t *testing.T) {
+	assert.PanicsWithError(t, "maxConcurrency must be greater than or equal to 0", func() {
+		NewPool(10).Resize(-1)
+	})
 }
 
 func TestPoolSubmitWhileStopping(t *testing.T) {

--- a/result.go
+++ b/result.go
@@ -11,9 +11,14 @@ type ResultPool[R any] interface {
 	basePool
 
 	// Submits a task to the pool and returns a future that can be used to wait for the task to complete and get the result.
+	// The pool will not accept new tasks after it has been stopped.
+	// If the pool has been stopped, this method will return ErrPoolStopped.
 	Submit(task func() R) Result[R]
 
 	// Submits a task to the pool and returns a future that can be used to wait for the task to complete and get the result.
+	// The task function must return a result and an error.
+	// The pool will not accept new tasks after it has been stopped.
+	// If the pool has been stopped, this method will return ErrPoolStopped.
 	SubmitErr(task func() (R, error)) Result[R]
 
 	// Creates a new subpool with the specified maximum concurrency and options.

--- a/result.go
+++ b/result.go
@@ -71,6 +71,9 @@ func newResultPool[R any](maxConcurrency int, parent *pool, options ...Option) *
 	}
 }
 
+// NewResultPool creates a new result pool with the given maximum concurrency and options.
+// Result pools are generic pools that can be used to submit tasks that return a result.
+// The new maximum concurrency must be greater than or equal to 0 (0 means no limit).
 func NewResultPool[R any](maxConcurrency int, options ...Option) ResultPool[R] {
 	return newResultPool[R](maxConcurrency, nil, options...)
 }

--- a/result_test.go
+++ b/result_test.go
@@ -98,7 +98,7 @@ func TestResultPoolSubpool(t *testing.T) {
 func TestResultSubpoolMaxConcurrency(t *testing.T) {
 	pool := NewResultPool[int](10)
 
-	assert.PanicsWithError(t, "maxConcurrency must be greater than 0", func() {
+	assert.PanicsWithError(t, "maxConcurrency must be greater than or equal to 0", func() {
 		pool.NewSubpool(-1)
 	})
 

--- a/subpool_test.go
+++ b/subpool_test.go
@@ -159,7 +159,7 @@ func TestSubpoolStop(t *testing.T) {
 func TestSubpoolMaxConcurrency(t *testing.T) {
 	pool := NewPool(10)
 
-	assert.PanicsWithError(t, "maxConcurrency must be greater than 0", func() {
+	assert.PanicsWithError(t, "maxConcurrency must be greater than or equal to 0", func() {
 		pool.NewSubpool(-1)
 	})
 


### PR DESCRIPTION
This pull request provides an alternative solution to the one proposed by @korotin in his pull request https://github.com/alitto/pond/pull/104 to address a race condition that can occur on `workersWaitGroup` when tasks are submitted while the pool is stopping.

## Changes
- Ensure `closed` atomic bool is toggled and checked while holding the mutex to avoid race conditions.
- Ensure `workersWaitGroup.Add()` is always called while holding the mutex to avoid race conditions.
- Improve comments on submit methods to clarify the behavior when the pool is stopped.
- Refactor `trySubmit` method to make it simpler and more clear.
- Centralize worker launch in a new method called `launchWorker`.
- Replace `subpoolSubmit` with `subpoolWorker` method.

## Fixes
- Decrement `workerCount` counter when the pool context is cancelled.
- `Resize()` now supports setting `maxConcurrency` to 0 (no limit) 
