### PR TITLE
feat(pool): add non-blocking submission methods and dropped tasks metric

### DIFF
--- a/group.go
+++ b/group.go
@@ -124,7 +124,7 @@ func (g *abstractTaskGroup[T, E, O]) submit(task any) {
 		}, err)
 
 		return err
-	})
+	}, g.pool.nonBlocking)
 
 	if err != nil {
 		g.taskWaitGroup.Done()

--- a/result_test.go
+++ b/result_test.go
@@ -110,3 +110,114 @@ func TestResultSubpoolMaxConcurrency(t *testing.T) {
 
 	assert.Equal(t, 10, subpool.MaxConcurrency())
 }
+
+func TestResultPoolTrySubmit(t *testing.T) {
+	pool := NewResultPool[int](1, WithQueueSize(1))
+	defer pool.StopAndWait()
+
+	completeFirstTask := make(chan struct{})
+
+	// Test successful submission
+	task, ok := pool.TrySubmit(func() int {
+		completeFirstTask <- struct{}{}
+		return 42
+	})
+	assert.True(t, ok)
+
+	// Test submission to queue
+	task2, ok := pool.TrySubmit(func() int {
+		return 43
+	})
+	assert.True(t, ok)
+
+	// Test failed submission when queue is full
+	task3, ok := pool.TrySubmit(func() int {
+		return 44
+	})
+	assert.True(t, !ok)
+
+	<-completeFirstTask
+
+	// Test submission to stopped pool
+	pool.StopAndWait()
+	_, ok = pool.TrySubmit(func() int {
+		return 45
+	})
+	assert.True(t, !ok)
+
+	// Verify tasks completed successfully
+	result, err := task.Wait()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 42, result)
+
+	result, err = task2.Wait()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 43, result)
+
+	result, err = task3.Wait()
+	assert.Equal(t, ErrQueueFull, err)
+	assert.Equal(t, 0, result)
+
+	// Verify metrics
+	assert.Equal(t, uint64(3), pool.SubmittedTasks())
+	assert.Equal(t, uint64(2), pool.CompletedTasks())
+	assert.Equal(t, uint64(2), pool.SuccessfulTasks())
+	assert.Equal(t, uint64(0), pool.FailedTasks())
+	assert.Equal(t, uint64(1), pool.DroppedTasks())
+}
+
+func TestResultPoolTrySubmitErr(t *testing.T) {
+	pool := NewResultPool[int](1, WithQueueSize(1))
+	defer pool.StopAndWait()
+
+	completeFirstTask := make(chan struct{})
+	sampleErr := errors.New("sample error")
+
+	// Test successful submission
+	task, ok := pool.TrySubmitErr(func() (int, error) {
+		completeFirstTask <- struct{}{}
+		return 42, nil
+	})
+	assert.True(t, ok)
+
+	// Test submission to queue with error
+	task2, ok := pool.TrySubmitErr(func() (int, error) {
+		return 0, sampleErr
+	})
+	assert.True(t, ok)
+
+	// Test failed submission when queue is full
+	task3, ok := pool.TrySubmitErr(func() (int, error) {
+		return 44, nil
+	})
+	assert.True(t, !ok)
+
+	<-completeFirstTask
+
+	// Test submission to stopped pool
+	pool.StopAndWait()
+	_, ok = pool.TrySubmitErr(func() (int, error) {
+		return 45, nil
+	})
+	assert.True(t, !ok)
+
+	// Verify tasks completed successfully
+	result, err := task.Wait()
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 42, result)
+
+	result, err = task2.Wait()
+	assert.Equal(t, sampleErr, err)
+	assert.Equal(t, 0, result)
+
+	result, err = task3.Wait()
+	assert.Equal(t, ErrQueueFull, err)
+	assert.Equal(t, 0, result)
+
+	// Verify metrics
+	assert.Equal(t, uint64(3), pool.SubmittedTasks())
+	assert.Equal(t, uint64(2), pool.CompletedTasks())
+	assert.Equal(t, uint64(1), pool.SuccessfulTasks())
+	assert.Equal(t, uint64(1), pool.FailedTasks())
+	assert.Equal(t, uint64(1), pool.DroppedTasks())
+}

--- a/subpool_test.go
+++ b/subpool_test.go
@@ -324,9 +324,11 @@ func TestSubpoolWithQueueSizeOverride(t *testing.T) {
 		subpool.Submit(task())
 	}
 
-	// 7 tasks should have been discarded
 	assert.Equal(t, int64(1), subpool.RunningWorkers())
-	assert.Equal(t, uint64(3), subpool.SubmittedTasks())
+	assert.Equal(t, uint64(11), subpool.SubmittedTasks())
+	assert.Equal(t, uint64(0), subpool.CompletedTasks())
+	assert.Equal(t, uint64(8), subpool.DroppedTasks())
+	assert.Equal(t, uint64(2), subpool.WaitingTasks())
 
 	// Unblock all running tasks
 	close(taskWait)


### PR DESCRIPTION
# Changes
- Add methods to submit individual tasks in a non-blocking fashion (`TrySubmit` and `TrySubmitErr`). This feature was requested in https://github.com/alitto/pond/issues/103
- Expose new `DroppedTasks` metric that reflects the number of tasks that were not executed because the queue was full. Issue reported in https://github.com/alitto/pond/issues/100
- `SubmittedTasks` metric now includes dropped tasks and it stops being updated once the pool is stopped.