### PR TITLE
fix(pool): prevent race condition with blocking pools

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -385,6 +385,9 @@ func (p *pool) trySubmit(task any) error {
 
 	p.launchWorker(task)
 
+	// Notify a submit waiter there is room in the queue for a new task
+	p.notifySubmitWaiter()
+
 	return nil
 }
 
@@ -420,6 +423,9 @@ func (p *pool) readTask() (task any, err error) {
 		p.workerCount.Add(-1)
 		p.workerWaitGroup.Done()
 		p.mutex.Unlock()
+
+		// Notify a submit waiter there is room in the queue for a new task
+		p.notifySubmitWaiter()
 
 		err = ErrQueueEmpty
 		return


### PR DESCRIPTION
# Fixes

- When a pool is configured in blocking mode, it could happen that a special sequence of calls to the `Submit` method produces some of them to block indefinitely if no more tasks are ever submitted to the pool before stopping it. This PR handles these corner cases by attempting to wake up submit waiters after submitting a task and after reading up all items from the queue.