### PR TITLE
feat(group): expose group context via Context() method

### DIFF
--- a/group.go
+++ b/group.go
@@ -34,6 +34,11 @@ type TaskGroup interface {
 
 	// Stops the group and cancels all remaining tasks. Running tasks are not interrupted.
 	Stop()
+
+	// Returns the context associated with this group.
+	// This context will be cancelled when either the parent context is cancelled
+	// or any task in the group returns an error, whichever comes first.
+	Context() context.Context
 }
 
 // ResultTaskGroup represents a group of tasks that can be executed concurrently.
@@ -81,6 +86,10 @@ func (g *abstractTaskGroup[T, E, O]) Done() <-chan struct{} {
 
 func (g *abstractTaskGroup[T, E, O]) Stop() {
 	g.future.Cancel(ErrGroupStopped)
+}
+
+func (g *abstractTaskGroup[T, E, O]) Context() context.Context {
+	return g.future.Context()
 }
 
 func (g *abstractTaskGroup[T, E, O]) Submit(tasks ...T) *abstractTaskGroup[T, E, O] {

--- a/internal/linkedbuffer/buffer_test.go
+++ b/internal/linkedbuffer/buffer_test.go
@@ -49,28 +49,21 @@ func TestBufferWithPointerToLargeObject(t *testing.T) {
 	}
 
 	runtime.ReadMemStats(&m)
-	before := int64(m.Alloc)
 
 	dataSize := 10 * 1024 * 1024
 	data := &Payload{
 		data: make([]byte, dataSize),
 	}
 
-	runtime.ReadMemStats(&m)
-	after := int64(m.Alloc)
-
-	// Verify large object allocated memory
-	assert.Equal(t, true, after-before >= int64(dataSize))
-
 	buffer := newBuffer[*Payload](10)
 
 	runtime.ReadMemStats(&m)
-	before = int64(m.Alloc)
+	before := int64(m.Alloc)
 
 	buffer.Write(data)
 
 	runtime.ReadMemStats(&m)
-	after = int64(m.Alloc)
+	after := int64(m.Alloc)
 
 	// Verify large object wasn't copied when writing it to the buffer
 	assert.Equal(t, true, after-before < int64(dataSize))

--- a/pool_test.go
+++ b/pool_test.go
@@ -323,7 +323,7 @@ func TestPoolResize(t *testing.T) {
 	assert.Equal(t, uint64(7), pool.WaitingTasks())
 	assert.Equal(t, int64(3), pool.RunningWorkers())
 
-	// Decrease max concurrency to 1
+	// Decrease max concurrency to 2
 	pool.Resize(2)
 	assert.Equal(t, 2, pool.MaxConcurrency())
 
@@ -338,7 +338,7 @@ func TestPoolResize(t *testing.T) {
 	}
 
 	// Ensure 2 tasks are running and 5 are waiting
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	assert.Equal(t, uint64(5), pool.WaitingTasks())
 	assert.Equal(t, int64(2), pool.RunningWorkers())
 

--- a/subpool_test.go
+++ b/subpool_test.go
@@ -400,7 +400,7 @@ func TestSubpoolResize(t *testing.T) {
 	}
 
 	// Ensure 2 tasks are running and 5 are waiting
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	assert.Equal(t, uint64(5), pool.WaitingTasks())
 	assert.Equal(t, int64(2), pool.RunningWorkers())
 	assert.Equal(t, int64(2), parentPool.RunningWorkers())


### PR DESCRIPTION
# Changes

- Expose the underlying group context via `group.Context()`. Related discussion: https://github.com/alitto/pond/discussions/120