### PR TITLE
feat(optional-panic-recovery): Add option to disable panic recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,16 @@ if err != nil {
 }
 ```
 
+If you prefer to keep the default Go runtime behavior (panics crashing the goroutine), you can disable panic interception when creating the pool:
+
+``` go
+pool := pond.NewPool(10, pond.WithoutPanicRecovery())
+
+pool.Go(func() {
+	panic("this panic will crash the goroutine")
+})
+```
+
 ### Subpools (v2)
 
 Subpools are pools that can have a fraction of the parent pool's maximum number of workers. This is useful when you need to create a pool of workers that can be used for a specific task or group of tasks.

--- a/group.go
+++ b/group.go
@@ -125,7 +125,7 @@ func (g *abstractTaskGroup[T, E, O]) submit(task any) {
 		}
 
 		// Invoke the task
-		output, err := invokeTask[O](task)
+		output, err := invokeTask[O](task, g.pool.panicRecovery)
 
 		g.futureResolver(index, &result[O]{
 			Output: output,

--- a/pool_test.go
+++ b/pool_test.go
@@ -76,6 +76,22 @@ func TestPoolSubmitWithPanic(t *testing.T) {
 	assert.Equal(t, nil, err)
 }
 
+func TestPoolDefaultHasPanicRecoveryEnabled(t *testing.T) {
+	p := NewPool(1)
+	defer p.Stop().Wait()
+
+	internalPool := p.(*pool)
+	assert.True(t, internalPool.panicRecovery)
+}
+
+func TestPoolWithoutPanicRecoveryOption(t *testing.T) {
+	p := NewPool(1, WithoutPanicRecovery())
+	defer p.Stop().Wait()
+
+	internalPool := p.(*pool)
+	assert.Equal(t, false, internalPool.panicRecovery)
+}
+
 func TestPoolSubmitWithErr(t *testing.T) {
 
 	pool := NewPool(100)

--- a/pooloptions.go
+++ b/pooloptions.go
@@ -27,3 +27,11 @@ func WithNonBlocking(nonBlocking bool) Option {
 		p.nonBlocking = nonBlocking
 	}
 }
+
+// WithoutPanicRecovery disables panic interception inside worker goroutines.
+// When this option is enabled, panics inside tasks will propagate just like regular goroutines.
+func WithoutPanicRecovery() Option {
+	return func(p *pool) {
+		p.panicRecovery = false
+	}
+}

--- a/result.go
+++ b/result.go
@@ -83,7 +83,7 @@ func (p *resultPool[R]) submit(task any, nonBlocking bool) (ResultTask[R], bool)
 		return future, false
 	}
 
-	wrapped := wrapTask[R, func(R, error)](task, resolve)
+	wrapped := wrapTask[R, func(R, error)](task, resolve, p.pool.panicRecovery)
 
 	if err := p.pool.submit(wrapped, nonBlocking); err != nil {
 		var zero R

--- a/task_test.go
+++ b/task_test.go
@@ -1,0 +1,30 @@
+package pond
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/alitto/pond/v2/internal/assert"
+)
+
+func TestInvokeTaskHandlesPanicByDefault(t *testing.T) {
+	sampleErr := errors.New("sample error")
+
+	err := func() (err error) {
+		_, err = invokeTask[struct{}](func() {
+			panic(sampleErr)
+		}, true)
+		return
+	}()
+
+	assert.True(t, errors.Is(err, ErrPanic))
+	assert.True(t, errors.Is(err, sampleErr))
+}
+
+func TestInvokeTaskWithoutPanicRecoveryPanics(t *testing.T) {
+	assert.PanicsWith(t, "boom", func() {
+		invokeTask[struct{}](func() {
+			panic("boom")
+		}, false)
+	})
+}


### PR DESCRIPTION
# Changes
Add option to disable panic recovery (`pond.WithoutPanicRecovery()`). This will cause panics thrown by tasks to be propagated to the caller scope and thus may cause the program to terminate if not explicitly recovered. This option is not enabled by default.

Feature requested in https://github.com/alitto/pond/issues/129