### PR TITLE
fix(stop-and-wait): handle call to runtime.Goexit() in task

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -232,6 +232,16 @@ func (p *pool) DroppedTasks() uint64 {
 
 func (p *pool) worker(task any) {
 	var readTaskErr, err error
+	exitedNormally := false
+	defer func() {
+		if !exitedNormally {
+			// In case of abnormal exit (e.g. runtime.Goexit() in the task),
+			// invoke readTask() to make sure the worker wait group is decremented
+			// and a submit waiter is notified to prevent deadlock
+			// (issue #135).
+			p.readTask()
+		}
+	}()
 	for {
 		if task != nil {
 			_, err = invokeTask[any](task, p.panicRecovery)
@@ -242,6 +252,7 @@ func (p *pool) worker(task any) {
 		task, readTaskErr = p.readTask()
 
 		if readTaskErr != nil {
+			exitedNormally = true
 			return
 		}
 	}

--- a/pool_test.go
+++ b/pool_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math"
 	"regexp"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -667,4 +668,29 @@ func TestPoolTrySubmitErr(t *testing.T) {
 	assert.Equal(t, uint64(1), pool.SuccessfulTasks())
 	assert.Equal(t, uint64(1), pool.FailedTasks())
 	assert.Equal(t, uint64(1), pool.DroppedTasks())
+}
+
+// TestStopAndWaitWithGoexit reproduces issue #135: StopAndWait() blocks indefinitely
+// when runtime.Goexit() is called inside a task. This commonly occurs with gomock
+// in unit tests, which uses runtime.Goexit() when expectations fail.
+func TestStopAndWaitWithGoexit(t *testing.T) {
+	pool := NewPool(10)
+
+	pool.SubmitErr(func() error {
+		runtime.Goexit()
+		return nil
+	})
+
+	done := make(chan struct{})
+	go func() {
+		pool.StopAndWait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// StopAndWait completed - bug is fixed
+	case <-time.After(2 * time.Second):
+		t.Fatal("StopAndWait() blocked indefinitely when runtime.Goexit() was called in a task (issue #135)")
+	}
 }


### PR DESCRIPTION
# Changes
- Ensure calls to `runtime.Goexit()` inside task functions doesn't cause the pool to hang later on when `StopAndWait()` is invoked.

Fixes https://github.com/alitto/pond/issues/135