### PR TITLE
fix(pool): ensure pool recovers after runtime.Goexit()

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -236,10 +236,18 @@ func (p *pool) worker(task any) {
 	defer func() {
 		if !exitedNormally {
 			// In case of abnormal exit (e.g. runtime.Goexit() in the task),
-			// invoke readTask() to make sure the worker wait group is decremented
-			// and a submit waiter is notified to prevent deadlock
-			// (issue #135).
-			p.readTask()
+			// launch a new worker to execute the next task in the queue.
+			p.updateMetrics(fmt.Errorf("worker exited abnormally: %w", err))
+
+			task, err := p.readTask()
+			if err != nil {
+				return
+			}
+
+			if task != nil {
+				p.launchWorker(task)
+				p.notifySubmitWaiter()
+			}
 		}
 	}()
 	for {

--- a/pool_test.go
+++ b/pool_test.go
@@ -691,6 +691,44 @@ func TestStopAndWaitWithGoexit(t *testing.T) {
 	case <-done:
 		// StopAndWait completed - bug is fixed
 	case <-time.After(2 * time.Second):
-		t.Fatal("StopAndWait() blocked indefinitely when runtime.Goexit() was called in a task (issue #135)")
+		t.Fatal("StopAndWait() blocked indefinitely")
+	}
+}
+
+// TestTaskInvokesGoexitAndRecover
+func TestTaskInvokesGoexitAndPoolRecovers(t *testing.T) {
+	pool := NewPool(1)
+
+	// Submit a task that will invoke runtime.Goexit() and kill the worker
+	taskGoexit := pool.SubmitErr(func() error {
+		runtime.Goexit()
+		return nil
+	})
+
+	// Submit another task that should execute normally after the first task is killed
+	taskNormal := pool.SubmitErr(func() error {
+		return nil
+	})
+
+	done := make(chan struct{})
+	go func() {
+		pool.StopAndWait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// StopAndWait completed
+		assert.Equal(t, ErrPoolStopped, taskGoexit.Wait())
+		assert.Equal(t, nil, taskNormal.Wait())
+
+		assert.Equal(t, int64(0), pool.RunningWorkers())
+		assert.Equal(t, uint64(2), pool.SubmittedTasks())
+		assert.Equal(t, uint64(2), pool.CompletedTasks())
+		assert.Equal(t, uint64(1), pool.SuccessfulTasks())
+		assert.Equal(t, uint64(1), pool.FailedTasks())
+		assert.Equal(t, uint64(0), pool.DroppedTasks())
+	case <-time.After(2 * time.Second):
+		t.Fatal("StopAndWait() blocked indefinitely")
 	}
 }


### PR DESCRIPTION
# Changes
- Ensure the pool recovers after one of the tasks kills one of the worker goroutines via `runtime.Goexit()`. A new worker is launched if there are tasks left in the queue and metrics are updated to account for the failed task.