### PR TITLE
fix: export BasePool interface for correct godoc rendering

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -34,8 +34,8 @@ var (
 	}()
 )
 
-// basePool is the base interface for all pool types.
-type basePool interface {
+// BasePool defines methods common to all pool types.
+type BasePool interface {
 	// Returns the number of worker goroutines that are currently active (executing a task) in the pool.
 	RunningWorkers() int64
 
@@ -94,7 +94,7 @@ type basePool interface {
 
 // Represents a pool of goroutines that can execute tasks concurrently.
 type Pool interface {
-	basePool
+	BasePool
 
 	// Submits a task to the pool without waiting for it to complete.
 	// The pool will not accept new tasks after it has been stopped.

--- a/result.go
+++ b/result.go
@@ -8,7 +8,7 @@ import (
 
 // ResultPool is a pool that can be used to submit tasks that return a result.
 type ResultPool[R any] interface {
-	basePool
+	BasePool
 
 	// Submits a task to the pool and returns a future that can be used to wait for the task to complete and get the result.
 	// The pool will not accept new tasks after it has been stopped.


### PR DESCRIPTION
Fixes #141

## Problem

The private `basePool` interface is embedded in both `Pool` and `ResultPool[R]`. Due to a [known Go doc limitation](https://github.com/golang/go/issues/2971), methods from embedded private interfaces are omitted from the generated documentation on [pkg.go.dev](https://pkg.go.dev/github.com/alitto/pond/v2#Pool).

This means essential methods like `RunningWorkers()`, `Stop()`, `StopAndWait()`, etc. are invisible in the docs.

## Fix

Rename `basePool` → `BasePool` (exported). This is a minor API addition (new exported type), not a breaking change — existing code embedding `Pool` or `ResultPool` continues to work.

## Testing

All existing tests pass.